### PR TITLE
feat(data): New endpoint to get all public surveys

### DIFF
--- a/data/urls.py
+++ b/data/urls.py
@@ -10,7 +10,7 @@ from django.urls import path
 from .views import FormListCreateView, FormDetailView
 from .views import QuestionListCreateView, QuestionDetailView
 from .views import ResponseListCreateView, ResponseDetailView
-from .views import custom_get_method, custom_post_method
+from .views import custom_get_method, custom_post_method, all_open_forms
 
 urlpatterns = [
     path('<str:hash>/form/', FormListCreateView.as_view(), name='form-list-create'),
@@ -21,4 +21,5 @@ urlpatterns = [
     path('<str:hash>/responses/<int:pk>', ResponseDetailView.as_view(), name='response-detail'),
     path('<str:hash>/voter/get-data', custom_get_method, name='form-get'),
     path('<str:hash>/voter/post-data', custom_post_method, name='form-post'),
+    path('voter/open-forms', all_open_forms, name='open-forms'),
 ]

--- a/data/views.py
+++ b/data/views.py
@@ -331,3 +331,22 @@ def populate_answers_and_responses(data, instance, user=None):
         raise e
     return_respnse = ResponseSerializer(response).data
     return return_respnse
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def all_open_forms(*args, **kwargs):
+    """
+    Get all the open forms for all the instances
+    """
+    domain = settings.DOMAIN
+    public_forms_hashes = []
+    try:
+        all_skeletons = Skeleton.objects.all()
+        for skeleton in all_skeletons:
+            if skeleton.instance.instance_auth_type == 0x1 << 0:
+                public_forms_hashes.append(domain + '/' + skeleton.instance.hash)
+    except Exception as e:
+        return JsonResponse({"detail": str(e)}, status=500)
+
+    return JsonResponse({"publicForms": public_forms_hashes}, status=200)


### PR DESCRIPTION
## Description

This PR introduces a new endpoint to get a list of all public surveys (links).

<img src="https://github.com/user-attachments/assets/2f3f25c5-8d61-42d6-a4e8-786e08d51580" width="70%">

Note: The domain here is dynamically fetched.


 ### How to test
- Make a `GET` request to `/api/v1/data/voter/open-forms`.
- You should be seeing the expected response.

Signed by Divij Sharma