### PR TITLE
feat(data): New endpoint to get all open forms

### DIFF
--- a/data/urls.py
+++ b/data/urls.py
@@ -21,5 +21,5 @@ urlpatterns = [
     path('<str:hash>/responses/<int:pk>', ResponseDetailView.as_view(), name='response-detail'),
     path('<str:hash>/voter/get-data', custom_get_method, name='form-get'),
     path('<str:hash>/voter/post-data', custom_post_method, name='form-post'),
-    path('voter/open-forms', all_open_forms, name='open-forms'),
+    path('voter/open-forms', all_open_forms, name='open-polls'),
 ]

--- a/data/views.py
+++ b/data/views.py
@@ -345,7 +345,10 @@ def all_open_forms(*args, **kwargs):
         all_skeletons = Skeleton.objects.all()
         for skeleton in all_skeletons:
             if skeleton.instance.instance_auth_type == 0x1 << 0:
-                public_forms_hashes.append(domain + '/' + skeleton.instance.hash)
+                public_forms_hashes.append({
+                    'title': skeleton.title,
+                    'link': domain + '/' + skeleton.instance.hash,
+                    'created_at': skeleton.created_at})
     except Exception as e:
         return JsonResponse({"detail": str(e)}, status=500)
 


### PR DESCRIPTION
## Description

This PR introduces a new endpoint to get a list of all public surveys (links).

<img src="https://github.com/user-attachments/assets/284f0474-0263-4feb-980b-40f2b3a99ff1" width="70%">

Note: The domain here is dynamically fetched.


 ### How to test
- Make a `GET` request to `/api/v1/data/voter/open-forms`.
- You should be seeing the expected response.

Signed by Divij Sharma