### PR TITLE
feat(OAuth): Add frontend redirect URI and handle exceptions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,8 @@ SOCIAL_AUTH_ALLOWED_REDIRECT_URIS = 'http://localhost:3000','http://your-product
 # Djoser settings
 DOMAIN = 'localhost:5173'
 SITE_NAME = 'Survey and Polls backend'
-FRONTEND_REDIRECT_URL = 'http://localhost:3000/selected-user-login'
+FRONTEND_REDIRECT_URL = 'http://localhost:3000/selected-user-login' #OAuth redirect URL handeling access token
+FRONTEND_REDIRECT_URL_NOTALLOWED = 'http://localhost:3000/blank-error' #URL to handle non-authorized users
 
 # Database settings
 DB_ENGINE = 'django.db.backends.<your db engine>' # NOTE: currently supported engines are: 'postgresql', 'mysql', 'sqlite3'

--- a/config/settings.py
+++ b/config/settings.py
@@ -208,5 +208,6 @@ DJOSER = {
     'PASSWORD_RESET_SHOW_EMAIL_NOT_FOUND': True
 }
 FRONTEND_REDIRECT_URL = os.environ.get('FRONTEND_REDIRECT_URL', 'http://localhost:3000/selected-user-login')
+FRONTEND_REDIRECT_URL_NOTALLOWED = os.environ.get('FRONTEND_REDIRECT_URL_NOTALLOWED', 'http://localhost:3000/blank-error')
 DOMAIN = os.environ.get('DOMAIN', 'http://localhost:3000')
 SITE_NAME = os.environ.get('SITE_NAME', 'SPAPI')


### PR DESCRIPTION
## Description

This PR adds redirect URI and handles some exception.

 ### How to test
- Add the `FRONTEND_REDIRECT_URL` value in  the `.env` file. The server will redirect to this URL with an access token in the query param.
- Get the `authorization_url` with redirect URL as `{domain}/api/v1/live/google-oauth2/callback/`.
- Navigate to this URL and sign in using your google account.
- You will be redirected to the forntend URL along with an access token for that user in the query param.

Signed by Divij Sharma